### PR TITLE
R6R test cleanup

### DIFF
--- a/src/components/legs/setup.tsx
+++ b/src/components/legs/setup.tsx
@@ -48,9 +48,11 @@ const LegsSetup = ({ game }: LegsSetupProps) => {
       setName('');
       setAddingPlayer(false);
       setSplashing(false);
+      /* istanbul ignore start -- @preserve */
     } catch (e) {
       console.log((e as Error).message);
     }
+    /* istanbul ignore stop -- @preserve */
   };
 
   return (

--- a/test/app.test.tsx
+++ b/test/app.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 
 import App from '~/app';
 
+vi.mock('react-router');
+
 describe('main app container', () => {
   it('renders without crashing', () => {
     const { container } = render(<App />);

--- a/test/components/legs/setup.test.tsx
+++ b/test/components/legs/setup.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
+import { cleanup, render, fireEvent, waitFor, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import LegsGame from '~/lib/legs/legs-game';
 import LegsSetup from '~/components/legs/setup';
@@ -11,6 +11,7 @@ vi.mock('~/lib/legs/legs-game', () => {
   MockLegsGame.create = vi.fn().mockImplementation(() => ({
     playerOrder: [],
     start: vi.fn(),
+    createPlayer: vi.fn(),
   }));
 
   return { default: MockLegsGame };
@@ -67,19 +68,22 @@ describe('LegsSetup', () => {
     expect(cancelButton).toBeTruthy();
     expect(enterButton.disabled).toBeTruthy();
 
-    fireEvent.change(nameInput, { target: { value: 'Artemis' } });
-    fireEvent.click(enterButton);
+    await act(() => {
+      fireEvent.change(nameInput, { target: { value: 'Artemis' } });
+      fireEvent.click(enterButton);
+    });
 
     expect(getAllByRole('textbox').length).toBeGreaterThan(1);
-    fireEvent.click(getByText('9'));
-    fireEvent.click(getByText('enter'));
 
-    waitFor(() => {
-      expect(getByText('add player')).toBeTruthy();
+    await act(() => {
+      fireEvent.click(getByText('9'));
+      fireEvent.click(getByText('enter'));
     });
+
+    expect(getByText('add player')).toBeTruthy();
   });
 
-  it('adds a player without a splash', () => {
+  it('adds a player without a splash', async () => {
     const { enterButton, cancelButton, nameInput, rendered } = startAddingPlayer();
     const { getAllByRole, getByText } = rendered;
 
@@ -87,14 +91,18 @@ describe('LegsSetup', () => {
     expect(cancelButton).toBeTruthy();
     expect(enterButton.disabled).toBeTruthy();
 
-    fireEvent.change(nameInput, { target: { value: 'Artemis' } });
-    fireEvent.click(enterButton);
+    await act(() => {
+      fireEvent.change(nameInput, { target: { value: 'Artemis' } });
+      fireEvent.click(enterButton);
+    });
 
     expect(getAllByRole('textbox').length).toBeGreaterThan(1);
-    waitFor(() => {
+
+    await act(() => {
       fireEvent.click(getByText('enter'));
-      expect(getByText('add player')).toBeTruthy();
     });
+
+    expect(getByText('add player')).toBeTruthy();
   });
 
   it('does not add a player with an invalid splash', () => {

--- a/test/components/shared/install-modal.test.tsx
+++ b/test/components/shared/install-modal.test.tsx
@@ -1,25 +1,32 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 
 import InstallModal from '~/components/shared/install-modal';
 import usePwaInstallation from '~/hooks/use-pwa-installation';
 
+vi.mock('@headlessui/react', () => ({
+  Description: ({ children }) => <div>{children}</div>,
+  Dialog: ({ children, open }) => (open ? <div>{children}</div> : null),
+  DialogPanel: ({ children }) => <div>{children}</div>,
+  DialogTitle: ({ children }) => <div>{children}</div>,
+  DialogBackdrop: () => null,
+}));
 vi.mock('~/hooks/use-pwa-installation');
 
-describe('Keypad', () => {
+describe('InstallModal', () => {
   const mockUsePwaInstallation = vi.mocked(usePwaInstallation);
 
   beforeEach(() => {
-    mockUsePwaInstallation.mockReturnValue({});
+    vi.mocked(usePwaInstallation).mockReturnValue({});
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    cleanup();
   });
 
-  it('renders without crashing', () => {
+  it('renders without crashing', async () => {
     const container = render(<InstallModal />);
+
     expect(container).to.exist;
   });
 
@@ -48,20 +55,26 @@ describe('Keypad', () => {
     expect(fallbackContainer).to.exist;
   });
 
-  it('invokes install prompt on install button click', () => {
+  it('invokes install prompt on install button click', async () => {
     const promptToInstall = vi.fn();
     mockUsePwaInstallation.mockReturnValue({ onIOS: false, hasPrompt: true, promptToInstall });
     const { getByText } = render(<InstallModal />);
 
-    fireEvent.click(getByText('Install'));
+    await act(() => {
+      fireEvent.click(getByText('Install'));
+    });
+
     expect(promptToInstall).toHaveBeenCalled();
   });
 
-  it('can be closed', () => {
+  it('can be closed', async () => {
     mockUsePwaInstallation.mockReturnValue({ hasPrompt: true });
     const { getByText, queryByText } = render(<InstallModal />);
 
-    fireEvent.click(getByText('Not now'));
+    await act(() => {
+      fireEvent.click(getByText('Not now'));
+    });
+
     expect(queryByText('Not now')).toBeNull();
   });
 });


### PR DESCRIPTION
- refactor tests per @testing-library/react and react-router warnings
- use more `act` calls in UI behavior verification
- ignore a catch clause until later when I deal with it more constructively